### PR TITLE
Loading nested configs only if var default matches var type

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -4,7 +4,7 @@ verify_ssl = true
 name = "pypi"
 
 [packages]
-file-config = {editable = true, extras = ["docs", "test"], path = "."}
+file-config = {editable = true,extras = ["docs", "test"],path = "."}
 
 [dev-packages]
 twine = "*"
@@ -15,8 +15,9 @@ flake8 = "*"
 towncrier = "*"
 colorama = "*"
 vprof = "*"
-readme_renderer = {version = "*", extras = ["md"]}
+readme_renderer = {version = "*",extras = ["md"]}
 pip-licenses = "*"
+ptpython = "*"
 
 [requires]
 python_version = "3.6"

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -36,7 +36,7 @@ sys.path.insert(0, BASE_DIR.joinpath("src").as_posix())
 # -- Project information -----------------------------------------------------
 
 project = title
-copyright = f"2018, {metadata['author']}"
+copyright = f"2019, {metadata['author']}"
 author = metadata["author"]
 
 # The short X.Y version

--- a/news/26.bugfix
+++ b/news/26.bugfix
@@ -1,0 +1,1 @@
+Adding the ability for nested configs to default to the empty state of the nested config if desired

--- a/news/copyright-year-update.misc
+++ b/news/copyright-year-update.misc
@@ -1,0 +1,1 @@
+Updating the copyright year in the docs to 2019

--- a/news/loading-defaults.doc
+++ b/news/loading-defaults.doc
@@ -1,0 +1,1 @@
+Adding documentation ``Loading Defaults`` in "Getting Started" regarding the different results when loading defaults from serialized content

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -23,13 +23,17 @@ def test_config_read_from_file_keeps_defaults():
         foo = file_config.var(str, default="Default", required=False)
         bar = file_config.var(str, default="Default", required=False)
 
-    yaml = dedent("""\
+    yaml = dedent(
+        """\
       foo: goofy
-    """)
+    """
+    )
 
-    json = dedent("""\
+    json = dedent(
+        """\
       {"foo": "goofy"}
-    """)
+    """
+    )
 
     internal_cfg = TestConfig(foo="goofy")
     yaml_cfg = TestConfig.loads_yaml(yaml)
@@ -45,7 +49,6 @@ def test_complex_config_deserialization_allows_nulls():
 
     @file_config.config
     class TestConfig:
-
         @file_config.config
         class InnerConfig:
             foo = file_config.var(str, default="Default", required=False)
@@ -53,10 +56,40 @@ def test_complex_config_deserialization_allows_nulls():
         inner = file_config.var(InnerConfig, required=False)
         bar = file_config.var(str, default="Default", required=False)
 
-    yaml = dedent("""\
+    yaml = dedent(
+        """\
       bar: goofy
-    """)
+    """
+    )
 
     yaml_cfg = TestConfig.loads_yaml(yaml)
 
-    assert yaml_cfg.bar == "goofy" and yaml_cfg.inner is None
+    assert yaml_cfg.bar == "goofy"
+    assert yaml_cfg.inner is None
+
+
+def test_complex_config_deserialization_handles_inner_configs():
+    from textwrap import dedent
+
+    @file_config.config
+    class TestConfig:
+        @file_config.config
+        class InnerConfig:
+            foo = file_config.var(str, default="Default", required=False)
+
+        inner = file_config.var(InnerConfig, required=False, default=InnerConfig)
+        bar = file_config.var(str, default="Default", required=False)
+
+    yaml = dedent(
+        """\
+        bar: goofy
+    """
+    )
+    yaml_cfg = TestConfig.loads_yaml(yaml)
+
+    assert yaml_cfg.bar == "goofy"
+    assert yaml_cfg.inner is not None and isinstance(
+        yaml_cfg.inner, TestConfig.InnerConfig
+    )
+    assert yaml_cfg.inner.foo == "Default"
+


### PR DESCRIPTION
This will hopefully fix #26

### Pull Request Checklist

Please review the [contributing guidelines](../CONTRIBUTING.rst) to this repository.

- [x] Make sure that you are requesting to pull a **feature/fix** branch.
- [x] Check that your code additions will not fail our requested style guidelines or linting checks.

### Description

<!-- Please provide a description of your pull request. -->
<!-- List out notable changes in list format below your description! -->

Adds the ability for nested configs to be loaded in in their "empty state" when the nested config var specifies the `default` kwarg as the nested config class.

For example:

```python
@file_config.config
class ParentConfig(object):
    @file_config.config
    class ChildConfig(object):
        bar = var(str, default="Default", required=False)

    foo = var(str, default="Default", required=False)
    bar = var(int)
    child = var(ChildConfig, default=ChildConfig, required=False)
```

The `child` var will be loaded with the `ChildConfig`'s default state if the content being loaded is missing the `child` attribute...

```python
config_2 = ParentConfig.loads_json('{"foo": "Testing", "bar": 1}')
print(config_2)
# ParentConfig(foo='Testing', bar=1, child=ParentConfig.ChildConfig(bar='Default'))
```

---

❤️ Thank you!
