### PR TITLE
Adding attrs kwarg passthrough

### DIFF
--- a/news/attrs-kwarg-passthrough.misc
+++ b/news/attrs-kwarg-passthrough.misc
@@ -1,0 +1,1 @@
+Adding kwarg passthrough for ``config`` so you can now use things like ``config(hash=True)``

--- a/src/file_config/_file_config.py
+++ b/src/file_config/_file_config.py
@@ -98,7 +98,7 @@ def _handle_load(cls, handler, file_object, validate=False, **kwargs):
     return from_dict(cls, handler.load(cls, file_object, **kwargs), validate=validate)
 
 
-def config(maybe_cls=None, these=None, title=None, description=None):
+def config(maybe_cls=None, these=None, title=None, description=None, **kwargs):
     """ File config class decorator.
 
     Usage is to simply decorate a **class** to make it a
@@ -155,7 +155,10 @@ def config(maybe_cls=None, these=None, title=None, description=None):
                     partialmethod(_handle_load, handler),
                 )
         config_vars = these if isinstance(these, dict) else None
-        return attr.s(config_cls, these=config_vars, slots=True)
+        config_options = {
+            key: value for (key, value) in kwargs.items() if key not in ("slots",)
+        }
+        return attr.s(config_cls, these=config_vars, slots=True, **config_options)
 
     if maybe_cls is None:
         return wrap


### PR DESCRIPTION
Signed-off-by: Stephen Bunn <stephen@bunn.io>

### Pull Request Checklist

Please review the [contributing guidelines](../CONTRIBUTING.rst) to this repository.

- [x] Make sure that you are requesting to pull a **feature/fix** branch.
- [x] Check that your code additions will not fail our requested style guidelines or linting checks.

### Description

Adds passthrough `kwargs` for `file_config.config` to `attr.s`. So now you should be able to do things like `config(hash=True)`

- Note that `slots` will have no effect on the config as they are already required for the config decorator to function correctly

---

❤️ Thank you!
