### PR TITLE
Fixing loading var types utilizing typehints

### DIFF
--- a/news/38.bugfix
+++ b/news/38.bugfix
@@ -1,0 +1,1 @@
+Allowing Python 3 typehints to be considered as the config var's type just like the var's ``type`` kwarg

--- a/news/collections-deprecation-warning.misc
+++ b/news/collections-deprecation-warning.misc
@@ -1,0 +1,1 @@
+Fixing access to collections.abc for Iterable deprecation warning

--- a/src/file_config/schema_builder.py
+++ b/src/file_config/schema_builder.py
@@ -391,7 +391,10 @@ def _build_var(var, property_path=None):
             schema["title"] = entry.title
         if isinstance(entry.description, str):
             schema["description"] = entry.description
-        if isinstance(entry.examples, collections.Iterable) and len(entry.examples) > 0:
+        if (
+            isinstance(entry.examples, collections.abc.Iterable)
+            and len(entry.examples) > 0
+        ):
             schema["examples"] = entry.examples
 
     # handle typing.Union types by simply using the "anyOf" key


### PR DESCRIPTION
### Pull Request Checklist

Please review the [contributing guidelines](../CONTRIBUTING.rst) to this repository.

- [x] Make sure that you are requesting to pull a **feature/fix** branch.
- [x] Check that your code additions will not fail our requested style guidelines or linting checks.

### Description

Fixes: #38 

Replace usage of `entry.type` with a ternary variable that will prioritize type kwargs from the metadata but fallback to the attrs attribute type (loaded from typehints). These changes are handled in both `_dump` and `_build` (anywhere we are accessing the `entry.type` from our var's metadata).

- Also fixing a deprecation warning from collections. Previously I was loading an abstract `Iterable` from the module-level (`collections.Iterable`). That is deprecated and was replaced with the new import `collections.abc.Iterable`.

---

❤️ Thank you!
