### PR TITLE
Configs can now define custom schema id and schema metadata properties

### DIFF
--- a/news/41.feature
+++ b/news/41.feature
@@ -1,0 +1,1 @@
+Adding the ability to define custom JSONSchema ``$id`` and ``$schema`` properties. Will raise user warnings if unsupported schema draft is specified.

--- a/src/file_config/_file_config.py
+++ b/src/file_config/_file_config.py
@@ -98,7 +98,15 @@ def _handle_load(cls, handler, file_object, validate=False, **kwargs):
     return from_dict(cls, handler.load(cls, file_object, **kwargs), validate=validate)
 
 
-def config(maybe_cls=None, these=None, title=None, description=None, **kwargs):
+def config(
+    maybe_cls=None,
+    these=None,
+    title=None,
+    description=None,
+    schema_id=None,
+    schema_draft=None,
+    **kwargs,
+):
     """ File config class decorator.
 
     Usage is to simply decorate a **class** to make it a
@@ -116,6 +124,10 @@ def config(maybe_cls=None, these=None, title=None, description=None, **kwargs):
     :param dict these: A dictionary of str to ``file_config.var`` to use as attribs
     :param str title: The title of the config, defaults to None, optional
     :param str description: A description of the config, defaults to None, optional
+    :param str schema_id: The JSONSchema ``$id`` to use when building the schema,
+        defaults to None, optional
+    :param str schema_raft: The JSONSchema ``$schema`` to use when building the schema,
+        defaults to None, optional
     :return: Config wrapped class
     :rtype: class
     """
@@ -128,7 +140,17 @@ def config(maybe_cls=None, these=None, title=None, description=None, **kwargs):
         :rtype: class
         """
 
-        setattr(config_cls, CONFIG_KEY, dict(title=title, description=description))
+        setattr(
+            config_cls,
+            CONFIG_KEY,
+            dict(
+                title=title,
+                description=description,
+                schema_id=schema_id,
+                schema_draft=schema_draft,
+            ),
+        )
+
         # dynamically assign available handlers to the wrapped class
         for handler_name in handlers.__all__:
             handler = getattr(handlers, handler_name)
@@ -241,7 +263,15 @@ def var(
     )
 
 
-def make_config(name, var_dict, title=None, description=None, **kwargs):
+def make_config(
+    name,
+    var_dict,
+    title=None,
+    description=None,
+    schema_id=None,
+    schema_draft=None,
+    **kwargs,
+):
     """ Creates a config instance from scratch.
 
     Usage is virtually the same as :func:`attr.make_class`.
@@ -256,6 +286,10 @@ def make_config(name, var_dict, title=None, description=None, **kwargs):
     :param dict var_dict: The dictionary of config variable definitions
     :param str title: The title of the config, defaults to None, optional
     :param str description: The description of the config, defaults to None, optional
+    :param str schema_id: The JSONSchema ``$id`` to use when building the schema,
+        defaults to None, optional
+    :param str schema_raft: The JSONSchema ``$schema`` to use when building the schema,
+        defaults to None, optional
     :return: A new config class
     :rtype: class
     """
@@ -265,6 +299,8 @@ def make_config(name, var_dict, title=None, description=None, **kwargs):
         these=var_dict,
         title=title,
         description=description,
+        schema_id=schema_id,
+        schema_draft=schema_draft,
     )
 
 

--- a/tests/handlers/test_msgpack.py
+++ b/tests/handlers/test_msgpack.py
@@ -21,7 +21,6 @@ def test_msgpack_reflective(instance):
             # deal with message pack limitations in integer limits
             assume(instance_arg >= -(2 ** 64) and instance_arg <= (2 ** 64) - 1)
 
-    print(instance)
     content = instance.dumps_msgpack(prefer="msgpack")
     assert isinstance(content, bytes)
     loaded = instance.__class__.loads_msgpack(content)


### PR DESCRIPTION
### Pull Request Checklist

Please review the [contributing guidelines](../CONTRIBUTING.rst) to this repository.

- [x] Make sure that you are requesting to pull a **feature/fix** branch.
- [x] Check that your code additions will not fail our requested style guidelines or linting checks.

### Description

Users can now explicitly define what they want the generated JSONSchema's `$id` or `$schema` properties to be in the `config()` decorator.

- `schema_id` - If defined, is used as the `$id` property (by default will use the class name with a `.json` extension. [`MyClass.json`])
- `schema_draft` - If defined, is used as the `$schema` property (by default will use the internally defined default schema draft.)

UserWarnings will be raised if the given custom `schema_draft` is not supported by `file_config`. **Use this parameter at your own peril.**

- Adding relevant tests to test default, good, and bad schema metadata
- Adding relevant news fragment
- Removing extraneous print statement in `msgpack` tests

Fixes: #41

---

❤️ Thank you!
